### PR TITLE
removes dependency on require.paths and fixes blocking error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,16 +1,15 @@
 # JS Beautifier, node.js version
 
 A fork of
-[github.com/einars/js-beautify](http://github.com/einars/js-beautify) to make
-it fit into my node.js setup while removing all the things I don't need
-(YMMV).
+[github.com/carlo/js-beautify-node](https://github.com/carlo/js-beautify-node to make
+it run as a command line utility
 
 
 ## Usage
 
 Beautify from the command line:
 
-    node beautify-node.js [options] [file || URL || STDIN]
+    jsbeautify [options] [file || URL || STDIN]
 
 
 ## Requirements
@@ -20,9 +19,8 @@ Beautify from the command line:
 
 ## Acknowledgements
 
-The original [JS Beautifier](http://github.com/einars/js-beautify) is written by [Einar Lielmanis](mailto:einar@jsbeautifier.org).  The core file `beautify.js` is virtually unchanged; I've only cleaned it up so I could lint it with my default JSLint settings should I decide to enhance it.
-
-I threw out pretty much everything else as I don't need it.
+- The original [JS Beautifier](http://github.com/einars/js-beautify) from [Einar Lielmanis](mailto:einar@jsbeautifier.org).  
+- [JS Beautifier Node](https://github.com/carlo/js-beautify-node
 
 
 ## License

--- a/beautify-node.js
+++ b/beautify-node.js
@@ -28,7 +28,6 @@ or working for you.
 */
 
 
-require.paths.unshift( "./" );
 
 
 ( function() {

--- a/beautify-node.js
+++ b/beautify-node.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*jslint adsafe: false, bitwise: true, browser: true, cap: false, css: false,
   debug: false, devel: true, eqeqeq: true, es5: false, evil: true,
   forin: false, fragment: false, immed: true, laxbreak: false, newcap: true,
@@ -36,14 +37,14 @@ or working for you.
     sys = require( "sys" ),
     http = require( "http" ),
     url = require( "url" ),
-    jsb = require( "beautify" ),
+    jsb = require( "./beautify.js" ),
     options,
     result = "";
 
 
   function printUsage() {
     sys.puts( [
-      "Usage: node beautify-node.js [options] [file || URL || STDIN]",
+      "Usage: jsbeautify [options] [file || URL || STDIN]",
       "",
       "Reads from standard input if no file or URL is specified.",
       "",


### PR DESCRIPTION
fixes this error in the latest unstable release of node:

```
Error: require.paths is removed. Use node_modules folders, or the NODE_PATH environment variable instead.
    at Function.<anonymous> (module.js:360:11)
    at Object.<anonymous> (beautify-node.js:32:8)
```
